### PR TITLE
Remove `route` property from Edge Config

### DIFF
--- a/dash/components/add.tsx
+++ b/dash/components/add.tsx
@@ -37,7 +37,7 @@ const Add = ({
     setDestination("");
     try {
       await mutate(add(route, destination, newData), {
-        optimisticData: newData,
+        optimisticData: { ...newData },
         rollbackOnError: true,
         revalidate: true,
         populateCache: true,

--- a/dash/components/add.tsx
+++ b/dash/components/add.tsx
@@ -32,10 +32,11 @@ const Add = ({
       visits: 0,
       status: "PENDING",
     };
+    newData = sort(newData);
     setRoute("");
     setDestination("");
     try {
-      await mutate(add(route, destination, 0, newData), {
+      await mutate(add(route, destination, newData), {
         optimisticData: newData,
         rollbackOnError: true,
         revalidate: true,

--- a/dash/components/add.tsx
+++ b/dash/components/add.tsx
@@ -5,7 +5,7 @@ import useSWR from "swr";
 import * as Dialog from "@radix-ui/react-dialog";
 import { ConfigData } from "../types/types";
 import { add } from "../lib/api";
-import { fetcher, server } from "../lib/helpers";
+import { fetcher, server, sort } from "../lib/helpers";
 
 const Add = ({
   open,
@@ -25,20 +25,18 @@ const Add = ({
   const [destination, setDestination] = useState("");
 
   async function handleSubmit() {
+    if (!data) return;
+    let newData: ConfigData = data;
+    newData[route] = {
+      destination,
+      visits: 0,
+      status: "PENDING",
+    };
     setRoute("");
     setDestination("");
-    if (!data) return;
-    const newData = data
-      .concat({
-        route,
-        destination,
-        visits: 0,
-        status: "PENDING",
-      })
-      .sort((a: ConfigData, b: ConfigData) => a.route.localeCompare(b.route));
     try {
       await mutate(add(route, destination, 0, newData), {
-        optimisticData: [...newData],
+        optimisticData: newData,
         rollbackOnError: true,
         revalidate: true,
         populateCache: true,

--- a/dash/components/add.tsx
+++ b/dash/components/add.tsx
@@ -14,9 +14,9 @@ const Add = ({
 }: {
   open: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
-  fallbackData: ConfigData[];
+  fallbackData: ConfigData;
 }) => {
-  const { data, mutate } = useSWR(`${server}/api/dash`, fetcher, {
+  const { data, mutate } = useSWR<ConfigData>(`${server}/api/dash`, fetcher, {
     suspense: true,
     fallbackData,
   });
@@ -27,6 +27,7 @@ const Add = ({
   async function handleSubmit() {
     setRoute("");
     setDestination("");
+    if (!data) return;
     const newData = data
       .concat({
         route,

--- a/dash/components/erase.tsx
+++ b/dash/components/erase.tsx
@@ -9,7 +9,7 @@ const Erase = ({
   fallbackData,
   route,
 }: {
-  fallbackData: ConfigData[];
+  fallbackData: ConfigData;
   route: string;
 }) => {
   const { data, mutate } = useSWR(`${server}/api/dash`, fetcher, {
@@ -45,7 +45,7 @@ const Erase = ({
                   const newData = deleteObject(route, data);
                   try {
                     await mutate(del(route, newData), {
-                      optimisticData: [...newData],
+                      optimisticData: newData,
                       rollbackOnError: true,
                       revalidate: false,
                       populateCache: true,
@@ -63,8 +63,9 @@ const Erase = ({
   );
 };
 
-function deleteObject(route: string, data: ConfigData[]) {
-  return data.filter((el) => el.route !== route);
+function deleteObject(route: string, data: ConfigData) {
+  delete data[route];
+  return data;
 }
 
 export default Erase;

--- a/dash/components/erase.tsx
+++ b/dash/components/erase.tsx
@@ -43,12 +43,13 @@ const Erase = ({
                 className="text-red11 bg-red4 hover:bg-red5 focus:shadow-black inline-flex h-[35px] items-center justify-center rounded-sm border-2 border-black shadow-button shadow-gray-800/80 px-[15px] font-medium leading-none outline-none focus:border-[2.75px]"
                 onClick={async () => {
                   if (!data) return;
-                  const newData = deleteObject(route, data);
+                  let newData: ConfigData = data;
+                  delete newData[route];
                   try {
                     await mutate(del(route, newData), {
-                      optimisticData: newData,
+                      optimisticData: { ...newData },
                       rollbackOnError: true,
-                      revalidate: false,
+                      revalidate: true,
                       populateCache: true,
                     });
                   } catch (err) {}
@@ -63,10 +64,5 @@ const Erase = ({
     </AlertDialog.Root>
   );
 };
-
-function deleteObject(route: string, data: ConfigData) {
-  delete data[route];
-  return data;
-}
 
 export default Erase;

--- a/dash/components/erase.tsx
+++ b/dash/components/erase.tsx
@@ -12,7 +12,7 @@ const Erase = ({
   fallbackData: ConfigData;
   route: string;
 }) => {
-  const { data, mutate } = useSWR(`${server}/api/dash`, fetcher, {
+  const { data, mutate } = useSWR<ConfigData>(`${server}/api/dash`, fetcher, {
     fallbackData,
   });
   return (
@@ -42,6 +42,7 @@ const Erase = ({
               <button
                 className="text-red11 bg-red4 hover:bg-red5 focus:shadow-black inline-flex h-[35px] items-center justify-center rounded-sm border-2 border-black shadow-button shadow-gray-800/80 px-[15px] font-medium leading-none outline-none focus:border-[2.75px]"
                 onClick={async () => {
+                  if (!data) return;
                   const newData = deleteObject(route, data);
                   try {
                     await mutate(del(route, newData), {

--- a/dash/components/listing.tsx
+++ b/dash/components/listing.tsx
@@ -35,7 +35,7 @@ const Listing = ({
   status?: Status;
   setSignInModalOpen: Dispatch<SetStateAction<boolean>>;
 }) => {
-  const { data, mutate } = useSWR(`${server}/api/dash`, fetcher, {
+  const { data, mutate } = useSWR<ConfigData>(`${server}/api/dash`, fetcher, {
     fallbackData,
   });
 
@@ -88,6 +88,7 @@ const Listing = ({
   }, [status]);
 
   async function handleMutate() {
+    if (!data) return;
     setEdit(false);
     if (newRoute === route && newDest === destination) return;
     if (!user) {

--- a/dash/components/listing.tsx
+++ b/dash/components/listing.tsx
@@ -11,6 +11,7 @@ import {
   fetcher,
   mutateObject,
   server,
+  sort,
 } from "../lib/helpers";
 import { ConfigData, EditItem, Status, User } from "../types/types";
 import Erase from "./erase";
@@ -29,7 +30,7 @@ const Listing = ({
   route: string;
   destination: string;
   visits: number;
-  fallbackData: ConfigData[];
+  fallbackData: ConfigData;
   fetchedBefore: boolean;
   status?: Status;
   setSignInModalOpen: Dispatch<SetStateAction<boolean>>;
@@ -96,17 +97,15 @@ const Listing = ({
     }
 
     setColor("amber-300");
-    let newData;
+    let newData: ConfigData = data;
     if (route !== newRoute) {
-      const filteredData = deleteObject(route, data);
-      newData = filteredData
-        .concat({
-          route: newRoute,
-          destination: newDest,
-          visits,
-          status: "PENDING",
-        })
-        .sort((a, b) => a.route.localeCompare(b.route));
+      newData = deleteObject(route, data);
+      newData[newRoute] = {
+        destination: newDest,
+        visits,
+        status: "PENDING",
+      };
+      newData = sort(newData);
     } else {
       newData = mutateObject("destination", data, newRoute, newDest);
     }

--- a/dash/components/listing.tsx
+++ b/dash/components/listing.tsx
@@ -115,7 +115,7 @@ const Listing = ({
           ? updateRoute(route, newRoute, newDest, visits, newData)
           : updateDestination(newRoute, newDest, visits, newData),
         {
-          optimisticData: [...newData],
+          optimisticData: newData,
           rollbackOnError: true,
           revalidate: route !== newRoute,
           populateCache: true,

--- a/dash/components/route-list.tsx
+++ b/dash/components/route-list.tsx
@@ -12,10 +12,10 @@ const RouteList = ({
   fallbackData,
   user,
 }: {
-  fallbackData: ConfigData[];
+  fallbackData: ConfigData;
   user: User;
 }) => {
-  const { data } = useSWR(`${server}/api/dash`, fetcher, {
+  const { data } = useSWR<ConfigData>(`${server}/api/dash`, fetcher, {
     suspense: true,
     fallbackData,
   });
@@ -48,19 +48,20 @@ const RouteList = ({
         <p className="sm:w-20"></p>
       </div>
       <div className="flex flex-col overflow-y-scroll max-h-[30rem]">
-        {data.map((listing: ConfigData) => (
-          <Listing
-            user={user}
-            key={listing.route}
-            route={listing.route}
-            destination={listing.destination}
-            visits={listing.visits}
-            fallbackData={fallbackData}
-            fetchedBefore={fetchedBefore}
-            status={listing.status}
-            setSignInModalOpen={setSignInModalOpen}
-          />
-        ))}
+        {data &&
+          Object.keys(data).map((route: string) => (
+            <Listing
+              user={user}
+              key={route}
+              route={route}
+              destination={data[route].destination}
+              visits={data[route].visits}
+              fallbackData={fallbackData}
+              fetchedBefore={fetchedBefore}
+              status={data[route].status}
+              setSignInModalOpen={setSignInModalOpen}
+            />
+          ))}
       </div>
       {user ? (
         <Add

--- a/dash/lib/api.ts
+++ b/dash/lib/api.ts
@@ -7,7 +7,7 @@ export async function add(
   route: string,
   destination: string,
   visits: number,
-  newData: ConfigData[]
+  newData: ConfigData
 ) {
   await fetch(url, {
     method: "PATCH",
@@ -32,9 +32,7 @@ export async function add(
     throw new Error(err);
   });
 
-  newData.map((obj) => {
-    if (obj.route === route) obj.status = "SUCCESS";
-  });
+  newData[route].status = "SUCCESS";
   await waitForPropagation(route);
   return newData;
 }
@@ -66,7 +64,7 @@ export async function updateRoute(
   newRoute: string,
   destination: string,
   visits: number,
-  newData: ConfigData[]
+  newData: ConfigData
 ) {
   await fetch(url, {
     method: "PATCH",
@@ -94,9 +92,7 @@ export async function updateRoute(
   }).catch((err) => {
     throw new Error(`${err}`);
   });
-  newData.map((obj) => {
-    if (obj.route === newRoute) obj.status = "SUCCESS";
-  });
+  newData[newRoute].status = "SUCCESS";
   await waitForPropagation(newRoute);
   return newData;
 }
@@ -105,7 +101,7 @@ export async function updateDestination(
   route: string,
   newDestination: string,
   visits: number,
-  newData: ConfigData[]
+  newData: ConfigData
 ) {
   await fetch(url, {
     method: "PATCH",
@@ -130,9 +126,7 @@ export async function updateDestination(
     throw new Error(err);
   });
 
-  newData.map((obj) => {
-    if (obj.route === route) obj.status = "SUCCESS";
-  });
+  newData[route].status = "SUCCESS";
   return newData;
 }
 
@@ -142,12 +136,8 @@ async function waitForPropagation(route: string, add = true) {
   // before returning data. If we didn't do this, the Optimistic UI
   // would update, but the row would then disappear when it revalidated.
   await delay(1000);
-  let all = await fetch(url).then((r) => r.json());
-  while (
-    add
-      ? !all.find((el: ConfigData) => el.route === route)
-      : all.find((el: ConfigData) => el.route === route)
-  ) {
+  let all: ConfigData = await fetch(url).then((r) => r.json());
+  while (add ? !all.hasOwnProperty(route) : all.hasOwnProperty(route)) {
     await delay(1000);
     all = await fetch(url).then((r) => r.json());
   }

--- a/dash/lib/api.ts
+++ b/dash/lib/api.ts
@@ -6,7 +6,6 @@ const url = `${server}/api/dash`;
 export async function add(
   route: string,
   destination: string,
-  visits: number,
   newData: ConfigData
 ) {
   await fetch(url, {
@@ -23,7 +22,7 @@ export async function add(
           value: {
             route,
             destination,
-            visits,
+            visits: 0,
           },
         },
       ],

--- a/dash/lib/api.ts
+++ b/dash/lib/api.ts
@@ -37,7 +37,7 @@ export async function add(
   return newData;
 }
 
-export async function del(route: string, newData: ConfigData[]) {
+export async function del(route: string, newData: ConfigData) {
   await fetch(url, {
     method: "PATCH",
     headers: {

--- a/dash/lib/helpers.ts
+++ b/dash/lib/helpers.ts
@@ -13,31 +13,35 @@ export const fetcher = (url: string) =>
     },
   }).then((r) => r.json());
 
-export function deleteObject(route: string, data: ConfigData[]) {
-  return data.filter((el) => el.route !== route);
+export function sort(data: ConfigData) {
+  return Object.keys(data)
+    .sort()
+    .reduce((obj: ConfigData, key) => {
+      obj[key] = data[key];
+      return obj;
+    }, {});
+}
+
+export function deleteObject(route: string, data: ConfigData) {
+  delete data[route];
+  return data;
 }
 
 export function mutateObject(
   toChange: string,
-  data: ConfigData[],
+  data: ConfigData,
   route: string,
   destination: string
 ) {
   if (toChange === "destination") {
-    data.map((obj) => {
-      if (obj.route === route) {
-        obj.destination = destination;
-        obj.status = "PENDING";
-      }
-    });
+    data[route].destination = destination;
+    data[route].status = "PENDING";
   }
   return data;
 }
 
-export function error(data: ConfigData[], route: string) {
-  data.map((obj) => {
-    if (obj.route === route) obj.status = "FAIL";
-  });
+export function error(data: ConfigData, route: string) {
+  data[route].status = "FAIL";
   return data;
 }
 

--- a/dash/pages/api/dash.ts
+++ b/dash/pages/api/dash.ts
@@ -4,7 +4,7 @@ import { getAll } from "@vercel/edge-config";
 export default async (req: NextRequest) => {
   if (req.method === "GET") {
     const configItems = await getAll();
-    return NextResponse.json(Object.values(configItems));
+    return NextResponse.json(configItems);
   } else if (req.method === "PATCH") {
     const authorization = req.headers.get("Authorization");
     if (!authorization) {

--- a/dash/types/types.ts
+++ b/dash/types/types.ts
@@ -6,12 +6,12 @@ export type User =
     }
   | undefined;
 
-export type ConfigData = {
-  route: string;
+export type ConfigValues = {
   destination: string;
   visits: number;
   status?: Status;
 };
+export type ConfigData = Record<string, ConfigValues>;
 
 export type Status = "PENDING" | "SUCCESS" | "FAIL" | "NEUTRAL";
 


### PR DESCRIPTION
Currently, a listing in the Edge Config for this project looks something like this:

```
"demo": {
  "route": "demo",
  "destination": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
  "visits": 40
}
```

I have `route` defined twice because of the way I'm fetching. Instead of returning the entire JSON object from Edge Config, I just return the values. But that removes the route name, but I still need the route name, so I added a `route` property. It's dumb!!!! And it adds unnecessary extra data to Edge Config which takes up storage space.

This PR fetches data the correct way, allowing me to remove the `route` property.